### PR TITLE
Append route classes to breadcrumb style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navigator",
-  "version": "0.0.16",
+  "version": "0.0.19",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navigator",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "license": "MIT",
   "scripts": {
     "ng": "ng",
@@ -11,9 +11,8 @@
     "e2e": "ng e2e",
     "make-comp": "tsc  && gulp less",
     "publish-dist": "rm -rf node_modules/ && rm -rf dist/ && npm install && npm run make-comp && npm publish dist/out-tsc/src/app/breadcrumb",
-    "clean-cmd" :"if exist node_modules rmdir /s /q node_modules && if exist dist rmdir /s /q dist",
+    "clean-cmd": "if exist node_modules rmdir /s /q node_modules && if exist dist rmdir /s /q dist",
     "publish-dist-cmd": "npm run clean-cmd && npm install && npm run make-comp && npm publish dist/out-tsc/src/app/breadcrumb"
-
   },
   "private": true,
   "dependencies": {
@@ -44,7 +43,6 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-typescript": "^3.1.4",
-
     "jasmine-core": "~2.5.2",
     "jasmine-spec-reporter": "~3.2.0",
     "karma": "~1.4.1",

--- a/packaging/package.json
+++ b/packaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-navigator",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "use as breadcrumb and as an optional navigator for angular 2",
   "main": "index.js",
   "scripts": {

--- a/src/app/breadcrumb/breadcrumb-model.ts
+++ b/src/app/breadcrumb/breadcrumb-model.ts
@@ -3,6 +3,7 @@ import {Params} from "@angular/router";
 import {Observable} from "rxjs/Observable";
 
 export interface Breadcrumb {
+  class?: string;
   label: string|Observable<string>;
   icon?: string;
   hide?: boolean

--- a/src/app/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/breadcrumb/breadcrumb.component.spec.ts
@@ -99,6 +99,12 @@ describe("breadcrumbComponent", () => {
         pos++;
       });
 
+      it('should append route classes to breadcrumb root element', () => {
+        const classes = expect(fixture.debugElement.query(By.css('.breadcrumb')).classes);
+        classes.toContain(breadcrumbAppendedClass0);
+        classes.toContain(breadcrumbAppendedClass1);
+      });
+
     });
     it('should have breadcrumbDropDown popup and bind to breadcrumbDropDown', () => {
       let breadcrumbPopups = fixture.debugElement.queryAll(By.directive(DcnBreadcrumbPopupStub));
@@ -115,6 +121,8 @@ describe("breadcrumbComponent", () => {
     });
   });
 
+  const breadcrumbAppendedClass0 = `spec-class0`;
+  const breadcrumbAppendedClass1 = `spec-class1`;
   function buildBreadcrumbs(url: string, visible: boolean, params = undefined): BreadcrumbRoute {
     return {
       breadcrumb: {
@@ -122,6 +130,7 @@ describe("breadcrumbComponent", () => {
         icon: url + "_icon",
         dropDown: {popupTitle: "aaa"},
         hide: visible,
+        class: `${breadcrumbAppendedClass0} ${breadcrumbAppendedClass1}`
       },
       params: params,
       url: url

--- a/src/app/breadcrumb/breadcrumb.component.ts
+++ b/src/app/breadcrumb/breadcrumb.component.ts
@@ -10,7 +10,7 @@ import {Observable} from "rxjs/Observable";
   styleUrls: ["breadcrumb.component.css"],
   template: `
 
-<div class="breadcrumb">
+<div [class]="'breadcrumb ' + class">
 
     <div *ngFor="let route of breadcrumbRoutes; let inx = index; let isLast=last" class="breadcrumb-holder">
         <a [routerLink]="[route.url]" class="breadcrumb-link">
@@ -26,6 +26,8 @@ import {Observable} from "rxjs/Observable";
 `
 })
 export class BreadcrumbComponent implements OnInit {
+
+  class: string;
 
   @Input()
   set homeBreadcrumb(breadcrumb: Breadcrumb) {
@@ -65,6 +67,12 @@ export class BreadcrumbComponent implements OnInit {
       this.breadcrumbRoutes.push(this.homeBreadcrumbRoute);
       this.breadcrumbRoutes.push(...this.breadcrumbService.getBreadcrumbs(this.activatedRoute.root)
         .filter(breadcrumb => !breadcrumb.breadcrumb.hide));
+
+      this.class =
+        this.breadcrumbRoutes
+        .map(b => b.breadcrumb.class)
+        .filter(c => !!c)
+        .join(' ');
     });
   }
 }


### PR DESCRIPTION
Each route can optionally include a class that will be appended to the breadcrumb top element classes.
This should allow us to customize the breadcrumb looks based on the current route.